### PR TITLE
Update to latest version of camel-snake-kebab

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [speclj "2.5.0"]
                  [ring/ring-codec "1.0.0"]
-                 [camel-snake-kebab "0.1.0"]
+                 [camel-snake-kebab "0.3.2"]
                  [org.clojure/data.xml "0.0.7"]
                  [org.clojure/data.json "0.2.1"]]
   :profiles {:dev {:dependencies [[speclj "2.5.0"]]}}

--- a/src/easy_bake_service/middleware/normalize.clj
+++ b/src/easy_bake_service/middleware/normalize.clj
@@ -3,7 +3,7 @@
     [easy-bake-service.json.parser       :refer [clj-map->json-str json-str->clj-map]]
     [easy-bake-service.xml.parser        :refer [hiccup->xml-str xml-str->hiccup]]
     [easy-bake-service.xml.value-fetcher :refer [tag-extractor]]
-    [camel-snake-kebab                   :as csk]
+    [camel-snake-kebab.core                   :as csk]
     [clojure.walk                        :as walk]
     [ring.util.codec                     :as ring]))
 

--- a/src/easy_bake_service/xml/parser.clj
+++ b/src/easy_bake_service/xml/parser.clj
@@ -1,7 +1,7 @@
 (ns easy-bake-service.xml.parser
   (:require
     [clojure.data.xml  :as xml]
-    [camel-snake-kebab :as csk]
+    [camel-snake-kebab.core :as csk]
     [clojure.string    :as string]))
 
 (defn- format-attributes [attributes]


### PR DESCRIPTION
The only change involved is referencing the *.core namespace instead of the old single element namespace.